### PR TITLE
used gist exmple of Popup + Progress Bar to show loading progress

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -7,6 +7,7 @@ ScreenManagement:
     ReadPlan:
     EditPlan:
 
+
 <LoginScreen>:
     ## TODO:  add logo to bottom of screen
     name: 'login'
@@ -296,16 +297,4 @@ ScreenManagement:
         on_release: app.root.current = 'read_plan'
         text: 'Edit Plan'
         font_size: 50
-
-<PopupBox>:
-    pop_up_text: _pop_up_text
-    size_hint: .5, .5
-    auto_dismiss: True
-    title: 'Status'
-
-    BoxLayout:
-        orientation: "vertical"
-        Label:
-            id: _pop_up_text
-            text: ''
 


### PR DESCRIPTION
Loading the autofinger list seems to be the only task (at the
moment) that is slower to do than loading the popup.  As such, I
removed other mentions of pop-up loading windows because the flash
that you can never read may be too distracting/confusing.  This
gist can always be used an example to extend loading to other
API calls (probably especially posting an edit) in the future as
needed.